### PR TITLE
Add NixOS Hyprland post-install setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# nixinst
+# NixOS Hyprland Post-Install Script
+
+This repository contains a single Bash script `postinstall_nixos_hyprland.sh` to help set up a Hyprland-based desktop on a freshly installed NixOS system.
+
+## Features
+- Verifies the script is run on NixOS as root
+- Prompts for the main user account
+- Optional installation of Home Manager
+- Clones your dotfiles repository
+- Offers to link or copy configs for Hyprland, Waybar, Fish, Fuzzel and custom scripts
+- Installs and enables Hyprland, Waybar, Fuzzel, Matugen, Ollama, Fish shell and common terminals
+- Lets you choose between editing system configuration or using Home Manager
+- Sets up and optionally preloads Ollama models
+- Sets Fish as the default shell
+- Detects additional drives and optionally adds them to configuration
+- Prompts to reboot when finished
+
+## Usage
+1. **Clone this repo** or copy the script onto your new NixOS install.
+2. Run the script as root:
+   ```bash
+   sudo ./postinstall_nixos_hyprland.sh
+   ```
+3. Follow the interactive prompts. Have your dotfiles repository URL handy.
+
+### Dotfiles Layout Example
+Your dotfiles repo should contain subdirectories like:
+```
+hypr/
+waybar/
+fish/
+fuzzel/
+scripts/
+```
+These will be linked or copied into `~/.config`.
+
+## Troubleshooting
+- Ensure you have network connectivity for cloning repos and installing packages.
+- If `home-manager` commands fail, check that the channel was added correctly.
+- Edit `/etc/nixos/configuration.nix` or your `home.nix` manually if needed and rerun `nixos-rebuild switch` or `home-manager switch`.
+
+## After Reboot
+- Log in and start Hyprland with `Hyprland` or via your display manager.
+- Waybar and Fuzzel should be available with your configurations.
+- Verify Ollama with `ollama list` and run models as desired.
+

--- a/postinstall_nixos_hyprland.sh
+++ b/postinstall_nixos_hyprland.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+
+# postinstall_nixos_hyprland.sh
+# Interactive post-installation setup for NixOS desktop with Hyprland.
+
+set -euo pipefail
+
+GREEN="[1;32m"
+RED="[1;31m"
+YELLOW="[1;33m"
+BLUE="[1;34m"
+RESET="[0m"
+
+ask() {
+  local prompt="$1" default=${2:-Y} reply
+  while true; do
+    if [[ $default == Y ]]; then
+      read -rp "$prompt [Y/n]: " reply
+      reply=${reply:-Y}
+    else
+      read -rp "$prompt [y/N]: " reply
+      reply=${reply:-N}
+    fi
+    case "$reply" in
+      [Yy]*) return 0;;
+      [Nn]*) return 1;;
+      *) echo "Please answer yes or no.";;
+    esac
+  done
+}
+
+require_root() {
+  if [[ $EUID -ne 0 ]]; then
+    echo -e "${RED}Run this script as root.${RESET}"
+    exit 1
+  fi
+}
+
+check_nixos() {
+  if [[ ! -f /etc/os-release ]] || ! grep -q '^ID=nixos' /etc/os-release; then
+    echo -e "${RED}This script must run on NixOS.${RESET}"
+    exit 1
+  fi
+}
+
+prompt_username() {
+  while true; do
+    read -rp "Enter your main (non-root) username: " USERNAME
+    if id "$USERNAME" &>/dev/null; then
+      break
+    else
+      echo -e "${RED}User '$USERNAME' not found.${RESET}"
+    fi
+  done
+}
+
+install_home_manager() {
+  if command -v home-manager &>/dev/null; then
+    echo -e "${GREEN}Home Manager already installed.${RESET}"
+    return
+  fi
+  if ask "Home Manager not found. Install it?" Y; then
+    echo -e "${BLUE}Installing Home Manager...${RESET}"
+    if ! nix-channel --list | grep -q home-manager; then
+      nix-channel --add https://github.com/nix-community/home-manager/archive/master.tar.gz home-manager
+      nix-channel --update
+    fi
+    nix-shell '<home-manager>' -A install
+  fi
+}
+
+prompt_dotfiles() {
+  read -rp "Enter URL or path to your dotfiles repo: " DOTFILES_REPO
+  local target="/home/$USERNAME/dotfiles"
+  if [[ -e $target ]]; then
+    if ask "$target exists. Remove and re-clone?" N; then
+      rm -rf "$target"
+    else
+      return
+    fi
+  fi
+  sudo -u "$USERNAME" git clone "$DOTFILES_REPO" "$target"
+}
+
+link_configs() {
+  local df="/home/$USERNAME/dotfiles"
+  local cfg="/home/$USERNAME/.config"
+  declare -A paths=([Hyprland]=hypr [Waybar]=waybar [Fish]=fish [Fuzzel]=fuzzel [Scripts]=scripts)
+  for app in "${!paths[@]}"; do
+    local src="$df/${paths[$app]}" dest="$cfg/${paths[$app]}"
+    [[ -e $src ]] || continue
+    if ask "Install $app config from $src to $dest?" Y; then
+      mkdir -p "$(dirname "$dest")"
+      if ask "Symlink instead of copy?" Y; then
+        ln -sfn "$src" "$dest"
+      else
+        rm -rf "$dest"
+        cp -r "$src" "$dest"
+      fi
+    fi
+  done
+}
+
+choose_install_method() {
+  if ask "Manage packages with Home Manager? (otherwise system configuration)" Y; then
+    INSTALL_METHOD=home
+  else
+    INSTALL_METHOD=system
+  fi
+}
+
+append_system_config() {
+  local conf=/etc/nixos/configuration.nix
+  local bak=/etc/nixos/configuration.nix.bak.$(date +%s)
+  cp "$conf" "$bak"
+  echo -e "${BLUE}Backup saved to $bak${RESET}"
+  if ! grep -q hyprland "$conf"; then
+    cat >> "$conf" <<'CFG'
+
+# Added by postinstall_nixos_hyprland.sh
+{ pkgs, ... }:
+{
+  programs.hyprland.enable = true;
+  programs.waybar.enable = true;
+  programs.fuzzel.enable = true;
+  programs.fish.enable = true;
+  environment.systemPackages = with pkgs; [ matugen ollama foot kitty ];
+  services.ollama.enable = true;
+}
+CFG
+  fi
+  nixos-rebuild switch
+}
+
+append_home_config() {
+  local hm=/home/$USERNAME/.config/home-manager/home.nix
+  sudo -u "$USERNAME" mkdir -p "$(dirname "$hm")"
+  if [[ -f $hm ]]; then
+    sudo -u "$USERNAME" cp "$hm" "$hm.bak.$(date +%s)"
+  fi
+  sudo -u "$USERNAME" bash -c "cat >> '$hm'" <<'HMCFG'
+
+# Added by postinstall_nixos_hyprland.sh
+{ pkgs, ... }:
+{
+  programs.hyprland.enable = true;
+  programs.waybar.enable = true;
+  programs.fuzzel.enable = true;
+  programs.fish.enable = true;
+  home.packages = with pkgs; [ matugen ollama foot kitty ];
+  services.ollama.enable = true;
+}
+HMCFG
+  sudo -u "$USERNAME" home-manager switch
+}
+
+setup_ollama() {
+  systemctl enable --now ollama.service
+  if ask "Preload Ollama models?" N; then
+    read -rp "Model names (space-separated): " models
+    for m in $models; do
+      sudo -u "$USERNAME" ollama pull "$m"
+    done
+  fi
+}
+
+set_fish_default() {
+  if ask "Set fish as default shell for $USERNAME?" Y; then
+    local fish_path=$(command -v fish)
+    if ! grep -q "$fish_path" /etc/shells; then
+      echo "$fish_path" >> /etc/shells
+    fi
+    chsh -s "$fish_path" "$USERNAME"
+  fi
+}
+
+auto_mount_drives() {
+  echo -e "${BLUE}Available block devices:${RESET}"
+  lsblk -o NAME,MOUNTPOINT,SIZE,TYPE | grep -E '^sd|^nvme'
+  read -rp "Enter device names to auto-mount (space-separated, blank to skip): " devs
+  [[ -z $devs ]] && return
+  local conf=/etc/nixos/configuration.nix
+  for d in $devs; do
+    local mp="/mnt/$d"
+    mkdir -p "$mp"
+    cat >> "$conf" <<EOF
+fileSystems."$mp" = {
+  device = "/dev/$d";
+  fsType = "auto";
+};
+EOF
+  done
+}
+
+final_prompt() {
+  if ask "Reboot now?" N; then
+    reboot
+  else
+    echo -e "${GREEN}Setup finished. Reboot when convenient.${RESET}"
+  fi
+}
+
+main() {
+  require_root
+  check_nixos
+  prompt_username
+  install_home_manager
+  prompt_dotfiles
+  link_configs
+  choose_install_method
+  if [[ $INSTALL_METHOD == home ]]; then
+    append_home_config
+  else
+    append_system_config
+  fi
+  setup_ollama
+  set_fish_default
+  auto_mount_drives
+  final_prompt
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add interactive `postinstall_nixos_hyprland.sh` for setting up Hyprland and related tools
- document usage in README

## Testing
- `bash -n postinstall_nixos_hyprland.sh`


------
https://chatgpt.com/codex/tasks/task_e_685af6b4d29c832195b3fd0306b30e8f