### PR TITLE
Fix creation of home-manager directory

### DIFF
--- a/postinstall_nixos_hyprland.sh
+++ b/postinstall_nixos_hyprland.sh
@@ -134,9 +134,11 @@ CFG
 
 append_home_config() {
   local hm=/home/$USERNAME/.config/home-manager/home.nix
-  sudo -u "$USERNAME" mkdir -p "$(dirname "$hm")"
+  local dir="$(dirname "$hm")"
+  mkdir -p "$dir"
+  chown -R "$USERNAME":"$USERNAME" "$dir"
   if [[ -f $hm ]]; then
-    sudo -u "$USERNAME" cp "$hm" "$hm.bak.$(date +%s)"
+    cp "$hm" "$hm.bak.$(date +%s)"
   fi
   sudo -u "$USERNAME" bash -c "cat >> '$hm'" <<'HMCFG'
 


### PR DESCRIPTION
## Summary
- update append_home_config to create `~/.config/home-manager` as root
- ensure ownership is set for the target user

## Testing
- `shellcheck postinstall_nixos_hyprland.sh | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685af92be9a48321a7e5cd01faed43b5