### PR TITLE
Fix group detection for append_home_config

### DIFF
--- a/postinstall_nixos_hyprland.sh
+++ b/postinstall_nixos_hyprland.sh
@@ -136,7 +136,12 @@ append_home_config() {
   local hm=/home/$USERNAME/.config/home-manager/home.nix
   local dir="$(dirname "$hm")"
   mkdir -p "$dir"
-  chown -R "$USERNAME":"$USERNAME" "$dir"
+  local group="$(id -gn "$USERNAME" 2>/dev/null || true)"
+  if [[ -n $group ]]; then
+    chown -R "$USERNAME":"$group" "$dir"
+  else
+    chown -R "$USERNAME" "$dir"
+  fi
   if [[ -f $hm ]]; then
     cp "$hm" "$hm.bak.$(date +%s)"
   fi


### PR DESCRIPTION
## Summary
- ensure append_home_config chowns using the user's primary group if it exists

## Testing
- `bash -n postinstall_nixos_hyprland.sh`


------
https://chatgpt.com/codex/tasks/task_e_685afaf810c4832186364f41273f0cc5